### PR TITLE
firefox opensearch 支持

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">
+    <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Luxirty Search">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Luxirty Search</title>
     <meta name="description" content="Luxirty Search 为专业人士优化，去除内容农场，无广告，简洁，快。">

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,0 +1,8 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+    <ShortName>Luxirty Search</ShortName>
+    <Description>Luxirty Search</Description>
+    <InputEncoding>UTF-8</InputEncoding>
+    <Image width="16" height="16" type="image/x-icon">/favicon.ico</Image>
+    <Url type="text/html" method="get" template="https://search.luxirty.com/search?q={searchTerms}"/>
+    <moz:SearchForm>/search</moz:SearchForm>
+</OpenSearchDescription>


### PR DESCRIPTION
为网站 https://search.luxirty.com 添加 opensearch 支持，效果如下：

![图片](https://github.com/user-attachments/assets/a4f4cb70-1a3e-456e-bd52-f7181b02653b)

issue 参考 #14

