### PR TITLE
fix: 当在URL自定义输入搜索为空时，跳回首页

### DIFF
--- a/src/components/Results.vue
+++ b/src/components/Results.vue
@@ -21,9 +21,13 @@
 <script>
 export default {
   name: 'SearchPage',
+  props: ['query'],
   mounted() {
     this.loadGoogleCSE();
     this.setupResultsRenderedCallback();  // 注册渲染结果回调函数
+    if (!this.query) {
+      history.back();
+    }
   },
   methods: {
     loadGoogleCSE() {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -14,7 +14,8 @@ const router = createRouter({
     {
       path: '/search',
       name: 'Results',
-      component: Results
+      component: Results,
+      props: route => ({ query: route.query.q })
     }
   ]
 })


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a4d47ab9-eb87-46d1-bd6e-cd23067926fd)
http://localhost:5173/search?q=
当输入内容为上方内容时，返回首页不展示白屏页面。
同时为了解决这问题https://github.com/KoriIku/luxirty-search/issues/11
